### PR TITLE
[feat] 펀딩 옵션 api 연동

### DIFF
--- a/src/apis/funding/useCommuFetch.ts
+++ b/src/apis/funding/useCommuFetch.ts
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { api } from "../AxiosInstance"
+import { api } from "../../AxiosInstance"
 
 interface QuestionAddProps {
 	projectId: string

--- a/src/apis/funding/useFundingFetch.ts
+++ b/src/apis/funding/useFundingFetch.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
-import { api } from "../AxiosInstance"
+import { api } from "../../AxiosInstance"
 import { useParams } from "react-router-dom"
-import { RewardData } from "../components/UI/FundingPage/modals/FundingModal"
+import { RewardData } from "../../components/UI/FundingPage/modals/FundingModal"
 
 interface FundingFetchProps {
     reward: RewardData

--- a/src/apis/funding/useFundingOptionFetch.ts
+++ b/src/apis/funding/useFundingOptionFetch.ts
@@ -1,0 +1,129 @@
+import { useEffect, useState, useCallback } from "react"
+import { api, apiWithoutCredentials } from "../../AxiosInstance"
+
+interface fundingOptionList {
+    id: number
+    price: number
+    description: string
+}
+
+interface responseFundingOptionList {
+    message: string
+    data: fundingOptionList[]
+}
+
+export const useGetFundingOptionList = (projectId: string) => {
+    const [optionList, setOptionList] = useState<fundingOptionList[]>([])
+    const [refetchTrigger, setRefetchTrigger] = useState(0)
+
+    const fetchOptionList = useCallback(async () => {
+        try {
+            const res = await apiWithoutCredentials.get<responseFundingOptionList>(`/public/option/${projectId}`)
+            setOptionList(res.data.data)
+        } catch (error) {
+            console.error('옵션 리스트 조회 실패:', error)
+        }
+    }, [projectId])
+
+    useEffect(() => {
+        fetchOptionList()
+    }, [fetchOptionList, refetchTrigger])
+
+    const refetch = () => {
+        setRefetchTrigger(prev => prev + 1)
+    }
+
+    return { optionList, refetch }
+}
+
+interface responseFundingOption {
+    message: string
+    data: null
+}
+
+interface requestFundingOptionAdd {
+    projectId: string
+    price: number
+    description: string
+}
+
+export const useAddFundingOption = () => {
+    const [isLoading, setIsLoading] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+
+    const addFundingOption = async ({ projectId, price, description }: requestFundingOptionAdd) => {
+        setIsLoading(true)
+        setError(null)
+
+        try {
+            const response = await api.post<responseFundingOption>(`/api1/option/${projectId}`, {
+                price: price,
+                description: description,
+            })
+            return response.data
+        } catch (error) {
+            setError(error instanceof Error ? error.message : '옵션 추가에 실패했습니다.')
+            throw error
+        } finally {
+            setIsLoading(false)
+        }
+    }
+
+    return { addFundingOption, isLoading, error }
+}
+
+interface requestFundingOptionUpdate {
+    optionId: number
+    price: number
+    description: string
+}
+
+export const useUpdateFundingOption = () => {
+    const [isLoading, setIsLoading] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+
+    const updateFundingOption = async ({ optionId, price, description }: requestFundingOptionUpdate) => {
+        setIsLoading(true)
+        setError(null)
+
+        try {
+            const response = await api.put<responseFundingOption>(`/api1/option/${optionId}`, {
+                price: price,
+                description: description,
+            })
+            return response.data
+        } catch (error) {
+            setError(error instanceof Error ? error.message : '옵션 수정에 실패했습니다.')
+            throw error
+        } finally {
+            setIsLoading(false)
+        }
+    }
+
+    return { updateFundingOption, isLoading, error }
+}
+
+interface requestFundingOptionDelete {
+    optionId: number
+}
+
+export const useDeleteFundingOption = () => {
+    const [isLoading, setIsLoading] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+
+    const deleteFundingOption = async ({ optionId }: requestFundingOptionDelete) => {
+        setIsLoading(true)
+        setError(null)
+        try {
+            const response = await api.delete<responseFundingOption>(`/api1/option/${optionId}`)
+            return response.data
+        } catch (error) {
+            setError(error instanceof Error ? error.message : '옵션 삭제에 실패했습니다.')
+            throw error
+        } finally {
+            setIsLoading(false)
+        }
+    }
+
+    return { deleteFundingOption, isLoading, error }
+}

--- a/src/apis/funding/useNoticeFetch.ts
+++ b/src/apis/funding/useNoticeFetch.ts
@@ -1,6 +1,6 @@
 import { useState } from "react"
-import { NoticeAddData } from "../types/project"
-import { api } from "../AxiosInstance"
+import { NoticeAddData } from "../../types/project"
+import { api } from "../../AxiosInstance"
 
 interface NoticeAddProps {
 	projectId: string

--- a/src/apis/funding/useProjectFetch.ts
+++ b/src/apis/funding/useProjectFetch.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { apiWithoutCredentials } from '../AxiosInstance'
+import { apiWithoutCredentials } from '../../AxiosInstance'
 import {
 	communityResponse,
 	detailResponse,
@@ -9,8 +9,8 @@ import {
 	ProjectNoticeData,
 	ProjectStoryData,
 	storyResponse,
-} from '../types/project'
-import { useProjectStore } from '../store/useProjectStore'
+} from '../../types/project'
+import { useProjectStore } from '../../store/useProjectStore'
 
 interface ProjectFetchProps {
 	projectId: string

--- a/src/apis/funding/useStoryFetch.ts
+++ b/src/apis/funding/useStoryFetch.ts
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { api } from "../AxiosInstance"
+import { api } from "../../AxiosInstance"
 
 interface StoryUpdateProps {
     projectId: string

--- a/src/components/UI/FundingPage/FundingInfo.tsx
+++ b/src/components/UI/FundingPage/FundingInfo.tsx
@@ -1,8 +1,9 @@
-import React, { JSX } from 'react'
+import React, { JSX, useState } from 'react'
 import ExamImage from '../../../assets/images/nextlevel.png'
 import LikeImage from '../../../assets/images/Like.svg'
 import { api } from '../../../AxiosInstance'
 import { useParams } from 'react-router-dom'
+import { FundingOptionManageModal } from './modals/FundingOptionManageModal'
 
 interface props {
 	setPayOpen: React.Dispatch<React.SetStateAction<boolean>>
@@ -14,14 +15,20 @@ interface props {
 	peopleNum: number
 	likeNum: number
 	tag: []
+	isAuthor: boolean
 }
 
-const FundingInfo = ({ setPayOpen, title, percent, image, description, amount, peopleNum, likeNum, tag }: props): JSX.Element => {
+const FundingInfo = ({ setPayOpen, title, percent, image, description, amount, peopleNum, likeNum, tag, isAuthor }: props): JSX.Element => {
 	const baseUrl = process.env.REACT_APP_API_BASE_URL
 	const { no } = useParams<{ no: string }>()
+	const [isOptionModalOpen, setIsOptionModalOpen] = useState(false)
 
 	const PayClick = () => {
 		setPayOpen(true)
+	}
+
+	const handleOptionManage = () => {
+		setIsOptionModalOpen(true)
 	}
 
 	const handleLike = async () => {
@@ -63,12 +70,24 @@ const FundingInfo = ({ setPayOpen, title, percent, image, description, amount, p
 					<img src={LikeImage} className='w-12 h-12 mb-1.5 hover:cursor-pointer transition-transform duration-200 group-hover:scale-110' onClick={handleLike} alt='좋아요' />
 					<p className='flex justify-center text-sm m-0 text-gray-500'>{likeNum}</p>
 				</div>
-				<button
-					className='bg-purple-500 hover:bg-purple-600 text-white border-none rounded-xl text-xl font-bold w-full h-12 hover:cursor-pointer transition-all duration-200 hover:shadow-lg hover:shadow-purple-500/30 hover:-translate-y-0.5'
-					onClick={PayClick}>
-					스타터와 함께하기
-				</button>
+				<div className='flex gap-2.5 ml-auto w-full'>
+					<button
+						className='bg-purple-500 hover:bg-purple-600 text-white border-none rounded-xl text-sm font-bold w-full h-12 hover:cursor-pointer transition-all duration-200 hover:shadow-lg hover:shadow-purple-500/30 hover:-translate-y-0.5'
+						onClick={PayClick}>
+						스타터와 함께하기
+					</button>
+					{isAuthor && (
+						<button
+							className='border-purple-500 text-purple-500 border-2 rounded-xl text-sm font-bold w-1/3 h-12 hover:cursor-pointer transition-all duration-200 hover:shadow-lg hover:shadow-purple-500/30 hover:-translate-y-0.5'
+							onClick={handleOptionManage}>
+							...
+						</button>
+					)}
+				</div>
 			</div>
+
+			{/* 옵션 관리 모달 */}
+			<FundingOptionManageModal isOpen={isOptionModalOpen} onClose={() => setIsOptionModalOpen(false)} projectId={no || ''} />
 		</div>
 	)
 }

--- a/src/components/UI/FundingPage/FundingMessage.tsx
+++ b/src/components/UI/FundingPage/FundingMessage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import QuestionModal from './modals/QuestionModal'
 import Modal from '../../layout/Modal'
-import { useCommunityDelete } from '../../../apis/useCommuFetch'
+import { useCommunityDelete } from '../../../apis/funding/useCommuFetch'
 
 interface AnswerData {
 	id: number

--- a/src/components/UI/FundingPage/FundingReward.tsx
+++ b/src/components/UI/FundingPage/FundingReward.tsx
@@ -41,9 +41,9 @@ const FundingReward = ({ id, price, title, checked, setSelectReward }: props): J
 				/>
 				<div className='flex-1'>
 					<div className='flex items-center justify-between mb-2'>
-						<span className={`font-bold text-2xl transition-colors duration-200 ${check ? 'text-purple-600' : 'text-gray-400'}`}>{price}</span>
+						<span className={`font-bold text-xl transition-colors duration-200 ${check ? 'text-purple-600' : 'text-gray-400'}`}>{price} P</span>
 					</div>
-					<p className={`font-bold text-lg mb-2 transition-colors duration-200 ${check ? 'text-gray-800' : 'text-gray-400'}`}>{title}</p>
+					<p className={`font-medium text-base mb-2 transition-colors duration-200 ${check ? 'text-gray-600' : 'text-gray-400'}`}>{title}</p>
 					<p className={`text-xs flex items-center gap-1 transition-colors duration-200 ${check ? 'text-purple-600' : 'text-gray-400'}`}>
 					</p>
 				</div>

--- a/src/components/UI/FundingPage/NewsContent.tsx
+++ b/src/components/UI/FundingPage/NewsContent.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { ChevronDown, ChevronUp } from 'lucide-react'
 import Modal from '../../layout/Modal'
 import NoticeModal from './modals/NoticeModal'
-import { useNoticeDelete } from '../../../apis/useNoticeFetch'
+import { useNoticeDelete } from '../../../apis/funding/useNoticeFetch'
 
 interface NewsContentProps {
 	title: string

--- a/src/components/UI/FundingPage/modals/FundingModal.tsx
+++ b/src/components/UI/FundingPage/modals/FundingModal.tsx
@@ -2,18 +2,8 @@ import React, { JSX, useEffect, useState } from 'react'
 import FundingReward from '../FundingReward'
 import FundingPay from '../FundingPay'
 import FundingFree from '../FundingFree'
-import { useFundingFetch, useGetFundingOption } from '../../../../apis/useFundingFetch'
+import { useFundingFetch, useGetFundingOption } from '../../../../apis/funding/useFundingFetch'
 import { useParams } from 'react-router-dom'
-
-const exam = [
-	{
-		id: 1,
-		price: '20000P',
-		title: '제목인데요?',
-		description: `설명인데요?`,
-		date: '2025년 3월 말 제공 예정',
-	},
-]
 
 export interface OptionRewardData {
 	optionId: number

--- a/src/components/UI/FundingPage/modals/FundingOptionForm.tsx
+++ b/src/components/UI/FundingPage/modals/FundingOptionForm.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react'
+
+interface FundingOptionFormProps {
+	onSubmit: (price: number, description: string) => void
+	onCancel: () => void
+	editMode?: boolean
+	initialData?: {
+		price: number
+		description: string
+	}
+}
+
+export const FundingOptionForm = ({ onSubmit, onCancel, editMode = false, initialData }: FundingOptionFormProps) => {
+	const [price, setPrice] = useState<string>(initialData?.price.toString() || '')
+	const [description, setDescription] = useState(initialData?.description || '')
+
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault()
+
+		// 유효성 검사
+		if (!price || parseInt(price) <= 0) {
+			alert('올바른 금액을 입력해주세요.')
+			return
+		}
+
+		if (!description.trim()) {
+			alert('옵션 설명을 입력해주세요.')
+			return
+		}
+
+		onSubmit(parseInt(price), description.trim())
+	}
+
+	return (
+		<form onSubmit={handleSubmit} className='bg-gradient-to-br from-purple-50 to-blue-50 rounded-xl p-6 border-2 border-purple-200'>
+			<div className='flex items-center justify-between mb-6'>
+				<h3 className='text-xl font-bold text-gray-800'>{editMode ? '옵션 수정' : '새 옵션 추가'}</h3>
+			</div>
+
+			<div className='space-y-5'>
+				{/* 금액 입력 */}
+				<div>
+					<label className='block text-sm font-semibold text-gray-700 mb-2'>
+						옵션 금액 <span className='text-red-500'>*</span>
+					</label>
+					<div className='relative'>
+						<input
+							type='number'
+							value={price}
+							onChange={(e) => setPrice(e.target.value)}
+							placeholder='10000'
+							className='w-full p-4 pr-12 border-2 border-gray-200 rounded-xl focus:border-purple-500 focus:outline-none transition-colors duration-200 bg-white'
+							min='0'
+						/>
+						<span className='absolute right-4 top-1/2 -translate-y-1/2 text-gray-500 font-semibold'>P</span>
+					</div>
+					<p className='text-xs text-gray-500 mt-1'>후원자가 선택할 때 표시될 금액입니다</p>
+				</div>
+
+				{/* 설명 입력 */}
+				<div>
+					<label className='block text-sm font-semibold text-gray-700 mb-2'>
+						옵션 설명 <span className='text-red-500'>*</span>
+					</label>
+					<textarea
+						value={description}
+						onChange={(e) => setDescription(e.target.value)}
+						placeholder='이 옵션에 대한 자세한 설명을 입력해주세요.'
+						className='w-full p-4 border-2 border-gray-200 rounded-xl focus:border-purple-500 focus:outline-none resize-none transition-colors duration-200 bg-white'
+						rows={4}
+					/>
+					<div className='flex justify-between items-center mt-1'>
+						<p className='text-xs text-gray-500'>옵션의 혜택, 포함 내역 등을 설명해주세요</p>
+						<span className='text-xs text-gray-400'>{description.length} / 200</span>
+					</div>
+				</div>
+			</div>
+
+			{/* 버튼 */}
+			<div className='flex gap-3 mt-6'>
+				<button
+					type='button'
+					onClick={onCancel}
+					className='flex-1 px-6 py-3 bg-gray-200 text-gray-700 rounded-xl font-semibold hover:bg-gray-300 transition-all duration-200'>
+					취소
+				</button>
+				<button
+					type='submit'
+					className='flex-1 px-6 py-3 bg-gradient-to-r from-blue-500 to-purple-500 text-white rounded-xl font-semibold shadow-lg hover:shadow-xl hover:from-blue-600 hover:to-purple-600 transition-all duration-200'>
+					{editMode ? '수정하기' : '추가하기'}
+				</button>
+			</div>
+		</form>
+	)
+}
+

--- a/src/components/UI/FundingPage/modals/FundingOptionList.tsx
+++ b/src/components/UI/FundingPage/modals/FundingOptionList.tsx
@@ -1,0 +1,65 @@
+interface FundingOption {
+    id: number
+    price: number
+    description: string
+}
+
+interface FundingOptionListProps {
+	options: FundingOption[]
+	onEdit: (id: number) => void
+	onDelete: (id: number) => void
+}
+
+export const FundingOptionList = ({ options, onEdit, onDelete }: FundingOptionListProps) => {
+	if (options.length === 0) {
+		return (
+			<div className='flex flex-col items-center justify-center py-16 text-gray-400'>
+				<svg xmlns='http://www.w3.org/2000/svg' className='h-16 w-16 mb-4' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
+					<path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4' />
+				</svg>
+				<p className='text-lg font-medium'>등록된 옵션이 없습니다</p>
+				<p className='text-sm mt-2'>새 옵션 추가 버튼을 눌러 첫 옵션을 만들어보세요!</p>
+			</div>
+		)
+	}
+
+	return (
+		<div className='space-y-4'>
+			{options.map((option) => (
+				<div key={option.id} className='border-2 border-gray-200 rounded-xl p-5 hover:border-purple-300 transition-all duration-200 hover:shadow-md bg-white'>
+					<div className='flex justify-between items-start'>
+						<div className='flex-1'>
+							<div className='flex items-center gap-3 mb-2'>
+								<h3 className='text-lg font-bold text-gray-800'>{option.description}</h3>
+								<span className='px-3 py-1 bg-purple-100 text-purple-700 text-sm font-semibold rounded-full'>
+									{option.price.toLocaleString()}P
+								</span>
+							</div>
+						</div>
+
+						{/* 수정/삭제 버튼 */}
+						<div className='flex gap-2 ml-4'>
+							<button
+								onClick={() => onEdit(option.id)}
+								className='px-4 py-2 bg-blue-500 text-white rounded-lg text-sm font-medium hover:bg-blue-600 hover:shadow-md active:scale-95 transition-all duration-200 flex items-center gap-1'>
+								<svg xmlns='http://www.w3.org/2000/svg' className='h-4 w-4' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
+									<path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z' />
+								</svg>
+								수정
+							</button>
+							<button
+								onClick={() => onDelete(option.id)}
+								className='px-4 py-2 bg-red-500 text-white rounded-lg text-sm font-medium hover:bg-red-600 hover:shadow-md active:scale-95 transition-all duration-200 flex items-center gap-1'>
+								<svg xmlns='http://www.w3.org/2000/svg' className='h-4 w-4' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
+									<path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16' />
+								</svg>
+								삭제
+							</button>
+						</div>
+					</div>
+				</div>
+			))}
+		</div>
+	)
+}
+

--- a/src/components/UI/FundingPage/modals/FundingOptionManageModal.tsx
+++ b/src/components/UI/FundingPage/modals/FundingOptionManageModal.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react'
+import { FundingOptionList } from './FundingOptionList'
+import { FundingOptionForm } from './FundingOptionForm'
+import { useAddFundingOption, useDeleteFundingOption, useGetFundingOptionList, useUpdateFundingOption } from '../../../../apis/funding/useFundingOptionFetch'
+
+interface FundingOptionManageModalProps {
+	isOpen: boolean
+	onClose: () => void
+	projectId: string
+}
+
+export const FundingOptionManageModal = ({ isOpen, onClose, projectId }: FundingOptionManageModalProps) => {
+	const { optionList, refetch } = useGetFundingOptionList(projectId)
+	const { addFundingOption } = useAddFundingOption()
+	const { updateFundingOption } = useUpdateFundingOption()
+	const { deleteFundingOption } = useDeleteFundingOption()
+	const [showForm, setShowForm] = useState(false)
+	const [editingOption, setEditingOption] = useState<{ id: number; price: number; description: string } | null>(null)
+
+	if (!isOpen) return null
+
+	const handleEdit = (id: number) => {
+		const option = optionList?.find((opt) => opt.id === id)
+		if (option) {
+			setEditingOption(option)
+			setShowForm(true)
+		}
+	}
+
+	const handleDelete = async (id: number) => {
+		if (window.confirm('정말 삭제하시겠습니까?')) {
+			try {
+				await deleteFundingOption({ optionId: id })
+				// 삭제 성공 후 리스트 새로고침
+				refetch()
+			} catch (error) {
+				console.error('삭제 실패:', error)
+			}
+		}
+	}
+
+	const handleAdd = () => {
+		setEditingOption(null)
+		setShowForm(true)
+	}
+
+	const handleFormSubmit = async (price: number, description: string) => {
+		try {
+			if (editingOption) {
+				// 수정 모드
+				await updateFundingOption({ optionId: editingOption.id, price, description })
+				console.log('수정 완료:', { id: editingOption.id, price, description })
+			} else {
+				// 추가 모드
+				await addFundingOption({ projectId, price, description })
+				console.log('추가 완료:', { price, description })
+			}
+			// API 성공 후 리스트 새로고침
+			refetch()
+			setShowForm(false)
+			setEditingOption(null)
+		} catch (error) {
+			console.error('옵션 저장 실패:', error)
+		}
+	}
+
+	const handleFormCancel = () => {
+		setShowForm(false)
+		setEditingOption(null)
+	}
+
+	return (
+		<div className='fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm' onClick={onClose}>
+			<div className='bg-white rounded-2xl shadow-2xl w-full max-w-4xl mx-4 max-h-[90vh] overflow-y-auto' onClick={(e) => e.stopPropagation()}>
+				{/* 헤더 */}
+				<div className='flex items-center justify-between p-6 border-b border-gray-200 bg-gradient-to-r from-purple-50 to-blue-50'>
+					<div>
+						<h2 className='text-2xl font-bold text-gray-800'>펀딩 옵션 관리</h2>
+						<p className='text-sm text-gray-600 mt-1'>스타터들이 선택할 수 있는 리워드 옵션을 관리하세요</p>
+					</div>
+				</div>
+
+			{/* 컨텐츠 영역 */}
+			<div className='p-6'>
+				{showForm ? (
+					// 옵션 추가/수정 폼
+					<FundingOptionForm
+						onSubmit={handleFormSubmit}
+						onCancel={handleFormCancel}
+						editMode={!!editingOption}
+						initialData={editingOption || undefined}
+					/>
+				) : (
+					// 옵션 리스트
+					<>
+						<button
+							onClick={handleAdd}
+							className='w-full py-4 px-6 mb-6 bg-gradient-to-r from-blue-500 to-purple-500 text-white rounded-xl font-semibold shadow-lg hover:shadow-xl hover:from-blue-600 hover:to-purple-600 hover:scale-[1.02] active:scale-[0.98] transition-all duration-200 flex items-center justify-center gap-2'>
+							<svg xmlns='http://www.w3.org/2000/svg' className='h-6 w-6' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
+								<path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M12 6v6m0 0v6m0-6h6m-6 0H6' />
+							</svg>
+							새 옵션 추가하기
+						</button>
+						<FundingOptionList options={optionList || []} onEdit={handleEdit} onDelete={handleDelete} />
+					</>
+				)}
+			</div>
+
+				{/* 푸터 */}
+				<div className='flex gap-3 p-6 border-t border-gray-200 bg-gray-50'>
+					<button
+						onClick={onClose}
+						className='flex-1 px-6 py-3 bg-gray-200 text-gray-700 rounded-xl font-semibold hover:bg-gray-300 transition-all duration-200'>
+						닫기
+					</button>
+				</div>
+			</div>
+		</div>
+	)
+}
+

--- a/src/components/UI/FundingPage/modals/NoticeModal.tsx
+++ b/src/components/UI/FundingPage/modals/NoticeModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import Modal from '../../../layout/Modal'
-import { useNoticeAdd, useNoticeUpdate } from '../../../../apis/useNoticeFetch'
+import { useNoticeAdd, useNoticeUpdate } from '../../../../apis/funding/useNoticeFetch'
 import { useParams } from 'react-router-dom'
 
 interface NoticeFormData {

--- a/src/components/UI/FundingPage/modals/QuestionModal.tsx
+++ b/src/components/UI/FundingPage/modals/QuestionModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import Modal from '../../../layout/Modal'
 import { useParams } from 'react-router-dom'
-import { useQuestionAdd, useAnswerAdd, useCommunityUpdate } from '../../../../apis/useCommuFetch'
+import { useQuestionAdd, useAnswerAdd, useCommunityUpdate } from '../../../../apis/funding/useCommuFetch'
 
 interface QuestionFormData {
 	content: string

--- a/src/components/UI/FundingPage/modals/StoryModal.tsx
+++ b/src/components/UI/FundingPage/modals/StoryModal.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from "react";
 import Modal from "../../../layout/Modal"
 import Swal from "sweetalert2";
-import { useStoryUpdate } from "../../../../apis/useStoryFetch";
+import { useStoryUpdate } from "../../../../apis/funding/useStoryFetch";
 import { useParams } from "react-router-dom";
 
 export const StoryModal = ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) => {

--- a/src/pages/FundingPage.tsx
+++ b/src/pages/FundingPage.tsx
@@ -1,17 +1,24 @@
-import React, { JSX, useState } from 'react'
+import React, { JSX, useEffect, useState } from 'react'
 import FundingInfo from '../components/UI/FundingPage/FundingInfo'
 import StarterInfo from '../components/UI/FundingPage/StarterInfo'
 import FundingContent from '../components/UI/FundingPage/FundingContent'
 import FundingModal from '../components/UI/FundingPage/modals/FundingModal'
 import Modal from '../components/layout/Modal'
 import { useParams } from 'react-router-dom'
-import { useProjectDetailFetch, useProjectFetch } from '../apis/useProjectFetch'
+import { useProjectDetailFetch, useProjectFetch } from '../apis/funding/useProjectFetch'
+import { useAuth } from '../hooks/AuthContext'
 
 const FundingPage = (): JSX.Element => {
 	const { no } = useParams<{ no: string }>()
 	const [payOpen, setPayOpen] = useState<boolean>(false)
 	const { story, notice, community } = useProjectFetch({ projectId: no ?? '' })
 	const { projectInfo } = useProjectDetailFetch({ projectId: no ?? '' })
+	const { user } = useAuth()
+	const [isAuthor, setIsAuthor] = useState<boolean>(false)
+
+	useEffect(() => {
+		setIsAuthor(user?.nickName === projectInfo?.user?.nickName)
+	}, [projectInfo])
 
 	return (
 		<div className='flex pl-[2%] gap-[2%] mx-[15%] mt-10'>
@@ -26,6 +33,7 @@ const FundingPage = (): JSX.Element => {
 					peopleNum={projectInfo?.fundingCount ?? 0}
 					likeNum={projectInfo?.likeCount ?? 0}
 					tag={projectInfo?.tag ?? []}
+					isAuthor={isAuthor}
 				/>
 				<StarterInfo starter={projectInfo?.user?.nickName ?? ''} />
 			</div>

--- a/src/pages/FundingPage.tsx
+++ b/src/pages/FundingPage.tsx
@@ -18,7 +18,7 @@ const FundingPage = (): JSX.Element => {
 
 	useEffect(() => {
 		setIsAuthor(user?.nickName === projectInfo?.user?.nickName)
-	}, [projectInfo])
+	}, [projectInfo, user])
 
 	return (
 		<div className='flex pl-[2%] gap-[2%] mx-[15%] mt-10'>


### PR DESCRIPTION
# [feat] 펀딩 옵션 api 연동

## Issue
- #81 

## 변경 내용
- 프로젝트 리워드 옵션 관련 api 연동
- 프로젝트 정보와 로그인 정보의 유저 닉네임이 동일할 때 옵션 설정 버튼이 보이도록 설정 (임의, 추후 isAuthor 제대로 기능 시 수정해야함)
- 펀딩 프로젝트 관련 api 로직들 경로 변경